### PR TITLE
解决下载有新增资源包文件报空指针的问题

### DIFF
--- a/Assets/Plugins/XAsset/Download.cs
+++ b/Assets/Plugins/XAsset/Download.cs
@@ -114,8 +114,10 @@ namespace Plugins.XAsset
                         len = fs.Length;
                         if (len < maxlen)
                         { 
-                            var emptyVersion = string.IsNullOrEmpty(version); 
-                            if (emptyVersion || !Versions.Get(savePath).Equals(version))
+                            var emptyVersion = string.IsNullOrEmpty(version);
+                            var oldVersion = Versions.Get(savePath);
+                            var emptyOldVersion = string.IsNullOrEmpty(oldVersion);
+                            if (emptyVersion || emptyOldVersion || !oldVersion.Equals(version))
                             {
                                 Versions.Set(savePath, version); 
                                 len = 0; 


### PR DESCRIPTION
解决了根据version.txt下载更新当有新增AB文件而导致的没有该文件旧version时在if里报nullrefrences的bug