### PR TITLE
manifest.name某些情况下返回空

### DIFF
--- a/Assets/Plugins/XAsset/Editor/BuildScript.cs
+++ b/Assets/Plugins/XAsset/Editor/BuildScript.cs
@@ -88,7 +88,7 @@ namespace Plugins.XAsset.Editor
 
         private static string[] GetLevelsFromBuildSettings()
         {
-            return new[] { EditorBuildSettings.scenes[0].path };
+            return EditorBuildSettings.scenes.Select(scene => scene.path).ToArray();
         }
 
         private static string GetAssetBundleManifestFilePath()

--- a/Assets/Plugins/XAsset/Editor/BuildScript.cs
+++ b/Assets/Plugins/XAsset/Editor/BuildScript.cs
@@ -303,7 +303,9 @@ namespace Plugins.XAsset.Editor
         public static void BuildManifest()
         {
             var manifest = GetManifest();
-            SetAssetBundleNameAndVariant(AssetDatabase.GetAssetPath(manifest), manifest.name.ToLower(), null);
+            var assetPath = AssetDatabase.GetAssetPath(manifest);
+            var bundleName = Path.GetFileNameWithoutExtension(assetPath).ToLower();
+            SetAssetBundleNameAndVariant(assetPath, bundleName, null);
         }
 
         public static void BuildAssetBundles()
@@ -424,7 +426,7 @@ namespace Plugins.XAsset.Editor
 #else
                     case BuildTarget.StandaloneOSXIntel:
                     case BuildTarget.StandaloneOSXIntel64:
-                    case BuildTarget.StandaloneOSXUniversal:               
+                    case BuildTarget.StandaloneOSXUniversal:
                                         return "/" + name + ".app";
 
 #endif


### PR DESCRIPTION
Manifest.asset在inspector点击reset后,调用.name返回空值(unity2018.4.4f1 osx), 导致异常