### PR TITLE
执行完拷贝资源到StreamingAsset以后自动刷新编辑器资源，提升用户体验

### DIFF
--- a/Assets/Plugins/XAsset/Editor/AssetsMenuItem.cs
+++ b/Assets/Plugins/XAsset/Editor/AssetsMenuItem.cs
@@ -80,6 +80,7 @@ namespace Plugins.XAsset.Editor
         private static void CopyAssetBundles()
         {
             BuildScript.CopyAssetBundlesTo(Path.Combine(Application.streamingAssetsPath, Utility.AssetBundles));
+            AssetDatabase.Refresh();
         }
 
         [MenuItem(KMarkAssetsWithDir)]


### PR DESCRIPTION
执行完拷贝资源到StreamingAsset步骤以后 
调用 AssetDatabase.Refresh(); 自动刷新编辑器资源，避免手动刷新，提升用户体验