### PR TITLE
文件较多时,标记很慢, 优化标记速度

### DIFF
--- a/Assets/Plugins/XAsset/Editor/AssetsMenuItem.cs
+++ b/Assets/Plugins/XAsset/Editor/AssetsMenuItem.cs
@@ -34,7 +34,7 @@ namespace Plugins.XAsset.Editor
     {
         private const string KMarkAssetsWithDir = "Assets/AssetBundles/按目录标记";
         private const string KMarkAssetsWithFile = "Assets/AssetBundles/按文件标记";
-        private const string KMarkAssetsWithName = "Assets/AssetBundles/按名称标记"; 
+        private const string KMarkAssetsWithName = "Assets/AssetBundles/按名称标记";
         private const string KBuildManifest = "Assets/AssetBundles/生成配置";
         private const string KBuildAssetBundles = "Assets/AssetBundles/生成資源包";
         private const string KBuildPlayer = "Assets/AssetBundles/生成播放器";
@@ -53,7 +53,7 @@ namespace Plugins.XAsset.Editor
                 if (!isRunning)
                 {
                     LaunchLocalServer.Run();
-                } 
+                }
             }
             else
             {
@@ -86,6 +86,7 @@ namespace Plugins.XAsset.Editor
         [MenuItem(KMarkAssetsWithDir)]
         private static void MarkAssetsWithDir()
         {
+            var assetsManifest = BuildScript.GetManifest();
             var assets = Selection.GetFiltered<Object>(SelectionMode.DeepAssets);
             for (var i = 0; i < assets.Length; i++)
             {
@@ -94,17 +95,19 @@ namespace Plugins.XAsset.Editor
                 if (Directory.Exists(path) || path.EndsWith(".cs", System.StringComparison.CurrentCulture))
                     continue;
                 if (EditorUtility.DisplayCancelableProgressBar(KMarkAssets, path, i * 1f / assets.Length))
-                    break; 
+                    break;
                 var assetBundleName = Path.GetDirectoryName(path).Replace("\\", "/") + "_g";
-                BuildScript.SetAssetBundleNameAndVariant(path, assetBundleName.ToLower(), null);
+                BuildScript.SetAssetBundleNameAndVariant(path, assetBundleName.ToLower(), null, assetsManifest);
             }
-
+            EditorUtility.SetDirty(assetsManifest);
+            AssetDatabase.SaveAssets();
             EditorUtility.ClearProgressBar();
         }
 
         [MenuItem(KMarkAssetsWithFile)]
         private static void MarkAssetsWithFile()
         {
+            var assetsManifest = BuildScript.GetManifest();
             var assets = Selection.GetFiltered<Object>(SelectionMode.DeepAssets);
             for (var i = 0; i < assets.Length; i++)
             {
@@ -113,8 +116,8 @@ namespace Plugins.XAsset.Editor
                 if (Directory.Exists(path) || path.EndsWith(".cs", System.StringComparison.CurrentCulture))
                     continue;
                 if (EditorUtility.DisplayCancelableProgressBar(KMarkAssets, path, i * 1f / assets.Length))
-                    break;  
-                
+                    break;
+
                 var dir = Path.GetDirectoryName(path);
                 var name = Path.GetFileNameWithoutExtension(path);
                 if (dir == null)
@@ -124,9 +127,10 @@ namespace Plugins.XAsset.Editor
                     continue;
 
                 var assetBundleName = TrimedAssetBundleName(Path.Combine(dir, name));
-                BuildScript.SetAssetBundleNameAndVariant(path, assetBundleName.ToLower(), null); 
+                BuildScript.SetAssetBundleNameAndVariant(path, assetBundleName.ToLower(), null, assetsManifest);
             }
-
+            EditorUtility.SetDirty(assetsManifest);
+            AssetDatabase.SaveAssets();
             EditorUtility.ClearProgressBar();
         }
 
@@ -134,6 +138,7 @@ namespace Plugins.XAsset.Editor
         private static void MarkAssetsWithName()
         {
             var assets = Selection.GetFiltered<Object>(SelectionMode.DeepAssets);
+            var assetsManifest = BuildScript.GetManifest();
             for (var i = 0; i < assets.Length; i++)
             {
                 var asset = assets[i];
@@ -141,13 +146,14 @@ namespace Plugins.XAsset.Editor
                 if (Directory.Exists(path) || path.EndsWith(".cs", System.StringComparison.CurrentCulture))
                     continue;
                 if (EditorUtility.DisplayCancelableProgressBar(KMarkAssets, path, i * 1f / assets.Length))
-                    break; 
+                    break;
                 var assetBundleName = Path.GetFileNameWithoutExtension(path);
-                BuildScript.SetAssetBundleNameAndVariant(path, assetBundleName.ToLower(), null);  
-            } 
-
+                BuildScript.SetAssetBundleNameAndVariant(path, assetBundleName.ToLower(), null, assetsManifest);
+            }
+            EditorUtility.SetDirty(assetsManifest);
+            AssetDatabase.SaveAssets();
             EditorUtility.ClearProgressBar();
-        } 
+        }
 
         [MenuItem(KBuildManifest)]
         private static void BuildManifest()

--- a/Assets/Plugins/XAsset/Editor/BuildScript.cs
+++ b/Assets/Plugins/XAsset/Editor/BuildScript.cs
@@ -240,11 +240,11 @@ namespace Plugins.XAsset.Editor
             EditorUtility.SetDirty(manifest);
         }
 
-
-        public static void SetAssetBundleNameAndVariant(string assetPath, string bundleName, string variant)
+        /// 传入manifestCache表示外部负责文件保存,避免 loop 中多次调用AssetDatabase.SaveAssets影响速度
+        public static void SetAssetBundleNameAndVariant(string assetPath, string bundleName, string variant, AssetsManifest manifestCache = null)
         {
-            var manifest = GetManifest();
-            var dir = System.IO.Path.GetDirectoryName(assetPath).Replace("\\", "/");
+            var manifest = manifestCache == null ? GetManifest() : manifestCache;
+            var dir = Path.GetDirectoryName(assetPath).Replace("\\", "/");
             var dirs = manifest.dirs;
             var dirIndex = ArrayUtility.FindIndex(dirs, (string obj) => { return obj == dir; });
 
@@ -291,13 +291,15 @@ namespace Plugins.XAsset.Editor
             }
 
             var asset = assets[assetIndex];
-            asset.name = System.IO.Path.GetFileName(assetPath);
+            asset.name = Path.GetFileName(assetPath);
             asset.bundle = bundleIndex;
             asset.variant = variantIndex;
             asset.dir = dirIndex;
-
-            EditorUtility.SetDirty(manifest);
-            AssetDatabase.SaveAssets();
+            if (manifestCache == null)
+            {
+                EditorUtility.SetDirty(manifest);
+                AssetDatabase.SaveAssets();
+            }
         }
 
         public static void BuildManifest()


### PR DESCRIPTION
避免循环中调用LoadAsset, AssetDatabase.SaveAssets影响标记速度