### PR TITLE
StartsWith is missing `StringComparison.Ordinal`

### DIFF
--- a/Assets/Plugins/XAsset/Assets.cs
+++ b/Assets/Plugins/XAsset/Assets.cs
@@ -216,8 +216,11 @@ namespace Plugins.XAsset
             }
             else
             {
-                if (path.StartsWith("http://") || path.StartsWith("https://") || path.StartsWith("file://") ||
-                    path.StartsWith("ftp://") || path.StartsWith("jar:file://"))
+                if (path.StartsWith("http://", StringComparison.Ordinal) ||
+                    path.StartsWith("https://", StringComparison.Ordinal) ||
+                    path.StartsWith("file://", StringComparison.Ordinal) ||
+                    path.StartsWith("ftp://", StringComparison.Ordinal) ||
+                    path.StartsWith("jar:file://", StringComparison.Ordinal))
                     asset = new WebAsset();
                 else
                     asset = new Asset();

--- a/Assets/Plugins/XAsset/Bundles.cs
+++ b/Assets/Plugins/XAsset/Bundles.cs
@@ -168,10 +168,10 @@ namespace Plugins.XAsset
 			}
 
 			Bundle bundle;
-			if (url.StartsWith ("http://") ||
-			    url.StartsWith ("https://") ||
-			    url.StartsWith ("file://") ||
-			    url.StartsWith ("ftp://"))
+			if (url.StartsWith ("http://", StringComparison.Ordinal) ||
+			    url.StartsWith ("https://", StringComparison.Ordinal) ||
+			    url.StartsWith ("file://", StringComparison.Ordinal) ||
+			    url.StartsWith ("ftp://", StringComparison.Ordinal))
 				bundle = new WebBundle {
 					hash = manifest != null ? manifest.GetAssetBundleHash (assetBundleName):new Hash128(),
 					cache = !isLoadingAssetBundleManifest

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ xasset 提供了一种使用资源路径的简单的方式来加载资源，简�
 
    这里主要说明如何基于 Demo 场景进行测试资源版本更新
 
-   首先，资源打包后，把 AssetsMenuItem 的 OnIntialize 替换为下面的样子：
+   首先，资源打包后，把 AssetsMenuItem 的 OnInitialize 替换为下面的样子：
 
    ```c#
    [InitializeOnLoadMethod]


### PR DESCRIPTION
This is a warning given with Visual Studio. Without specifying `Ordinal`, the comparison will be culture dependant and potentially slower.