### PR TITLE
版本判断宏定义符号无效的问题

### DIFF
--- a/Assets/XAsset/Editor/MenuItems.cs
+++ b/Assets/XAsset/Editor/MenuItems.cs
@@ -155,7 +155,7 @@ namespace libx
             BuildScript.CopyAssetBundlesTo(Application.streamingAssetsPath);
         } 
 
-#if !UNITY_2018_OR_NEWER
+#if !UNITY_2018_1_OR_NEWER
         private const string KCopyPath = "Assets/Copy Path";
         [MenuItem(KCopyPath)]
         private static void CopyPath()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24813704/87749914-927cf380-c82c-11ea-9d4a-d68b59a1ec02.png)

![image](https://user-images.githubusercontent.com/24813704/87749927-99a40180-c82c-11ea-9e9e-c527d4b3a912.png)

目前的写法在高版本Unity中并未生效， 测试版本为2019.4.0f1