### PR TITLE
切到后台再切回来无法继续下载

### DIFF
--- a/Assets/XAsset/Runtime/Core/Downloader.cs
+++ b/Assets/XAsset/Runtime/Core/Downloader.cs
@@ -86,7 +86,9 @@ namespace libx
             _lastTime = 0;
             _started = true;
             _downloadIndex = _finishedIndex;
-            var max = Math.Min(_downloads.Count, maxDownloads);
+            var max = _downloads.Count <= maxDownloads ? _downloads.Count : _finishedIndex + maxDownloads;
+            if (max > _downloads.Count)
+                max = _downloads.Count;
             for (var i = _finishedIndex; i < max; i++)
             {
                 var item = _downloads[i];


### PR DESCRIPTION
如果_downloads.Count大于maxDownloads，且_finishedIndex大于maxDownloads，下载就无法继续。这在下载数量大于maxDownloads，手机切到后台再切回来时会触发，无法继续下载。
另外，对于maxDownloads，如果数量大于1会有另外一个问题：
同时开启多个下载任务，在Restart时会因为_finishedIndex递增出问题。对于下载速度不一样的任务，_finishedIndex不能表示"前一个"下载完成的任务，只能表示多个下载任务中最先下载完成的，单纯的++_finishedIndex就会出现问题。多个任务中间没有下载完成的，在Restart开始后就不会再进入下载列表了(_finishedIndex递增把索引覆盖了)
所以要么维护一个finishedIndex的下载列表，要么就始终将maxDownloads设置成一，否则切后台再切回来就会有问题。