### PR TITLE
downloader index bug

### DIFF
--- a/Assets/XAsset/Runtime/Core/Download.cs
+++ b/Assets/XAsset/Runtime/Core/Download.cs
@@ -39,7 +39,6 @@ namespace libx
         {
             return new Download()
             {
-                id = id,
                 hash = hash,
                 url = url,
                 len = len,
@@ -50,8 +49,6 @@ namespace libx
         }
 
         #endregion
-
-        public int id { get; set; }
 
         public string error { get; private set; }
 
@@ -227,6 +224,7 @@ namespace libx
                 else
                 {
                     File.Delete(tempPath);
+                    Start();
                 } 
             }
             else

--- a/Assets/XAsset/Runtime/Core/Updater.cs
+++ b/Assets/XAsset/Runtime/Core/Updater.cs
@@ -544,7 +544,7 @@ namespace libx
             if (enableVFS)
             {
                 var dataPath = _savePath + Versions.Dataname;
-                var downloads = _downloader.downloads;
+                var downloads = _downloader.finished;
                 if (downloads.Count > 0 && File.Exists(dataPath))
                 {
                     OnMessage("更新本地版本信息");


### PR DESCRIPTION
如果有三个下载download1,download2,download3,如果download2较早下载完，这时候downloader先Stop再Restart,使用_downloadIndex就会有问题，会去下载download2,download3，这时就出错了，应该是去下载download1,download3